### PR TITLE
fix: Prevent fragment from resetting on screen rotation

### DIFF
--- a/app/src/main/java/com/example/projet_mobile1/MainActivity.java
+++ b/app/src/main/java/com/example/projet_mobile1/MainActivity.java
@@ -48,28 +48,30 @@ public class MainActivity extends AppCompatActivity {
         Drawable overflowIcon = toolbar.getOverflowIcon();
         overflowIcon.setTint(ContextCompat.getColor(this, R.color.white));
 
-        String fragmentName = getIntent().getStringExtra("fragment");
-        if (fragmentName != null){
-            Fragment fragmentToLoad = null;
-            switch (fragmentName){
-                case "PanierFragment":
-                    fragmentToLoad = new PanierFragment();
-                    break;
-                case "AddEditFragment":
-                    fragmentToLoad = new AddEditFragment();
-                    break;
-                case "ListeArticlesFragment":
-                default:
-                    fragmentToLoad = new ListeArticlesFragment();
-                    break;
+        if (savedInstanceState == null) {
+            String fragmentName = getIntent().getStringExtra("fragment");
+            if (fragmentName != null) {
+                Fragment fragmentToLoad = null;
+                switch (fragmentName) {
+                    case "PanierFragment":
+                        fragmentToLoad = new PanierFragment();
+                        break;
+                    case "AddEditFragment":
+                        fragmentToLoad = new AddEditFragment();
+                        break;
+                    case "ListeArticlesFragment":
+                    default:
+                        fragmentToLoad = new ListeArticlesFragment();
+                        break;
+                }
+                getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.fragmentContainer, fragmentToLoad)
+                        .commit();
+            } else {
+                getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.fragmentContainer, new ListeArticlesFragment())
+                        .commit();
             }
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragmentContainer, fragmentToLoad)
-                    .commit();
-        } else {
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragmentContainer, new ListeArticlesFragment())
-                    .commit();
         }
     }
 


### PR DESCRIPTION
The app now correctly retains the current fragment (e.g., the shopping cart) when the screen is rotated.

cc: @roastedbysaby can you PTAL and merge if everything look good to you?